### PR TITLE
Fixed parse escaped value with space at end of string

### DIFF
--- a/snmpsim/grammar/snmprec.py
+++ b/snmpsim/grammar/snmprec.py
@@ -48,7 +48,7 @@ class SnmprecGrammar(AbstractGrammar):
 
     def parse(self, line):
         try:
-            oid, tag, value = octs2str(line).strip().split('|', 2)
+            oid, tag, value = octs2str(line).split('|', 2)
 
         except Exception as exc:
             raise error.SnmpsimError(
@@ -56,7 +56,7 @@ class SnmprecGrammar(AbstractGrammar):
 
         else:
             if oid and tag:
-                return oid, tag, value
+                return oid.strip(), tag.strip(), value.strip("\r\n\t")
 
             raise error.SnmpsimError('broken record <%s>' % line)
 


### PR DESCRIPTION
For some escaped values get error:
```
ERROR data error at loadmaster.snmprec controller for 1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.31: value evaluation error for tag '64', value [85, 209, 202]: Bad IP address syntax
```

for such request:
```
$ snmpwalk -v2c -c community -Pu -M ../rfc:../net-snmp:. -m ALL hostname .1.3.6.1.2.1.3.1.1.3.3.1
RFC1213-MIB::atNetAddress.3.1.85.209.202.31 = Network Address: 55:D1:CA:1F
RFC1213-MIB::atNetAddress.3.1.85.209.202.31 = No more variables left in this MIB View (It is past the end of the MIB tree)
```

this is part of loadmaster.snmprec:
```
1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.31|64e|U\xd1\xca\x1f
1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.32|64e|U\xd1\xca
```
there in last line space at end of string, which should be converted to number 32.