### PR TITLE
Fixed paths for variation and data dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ params.update(
 
 # install stock variation modules as data_files
 params['data_files'] = [
-    (os.path.join('snmpsim', 'variation'),
+    (os.path.join('share', 'snmpsim', 'variation'),
      glob.glob(os.path.join('variation', '*.py')))
 ]
 
@@ -106,7 +106,7 @@ for x in os.walk('data'):
     files.extend(glob.glob(os.path.join(x[0], '*.sapwalk')))
 
     params['data_files'].append(
-        (os.path.join('snmpsim', *os.path.split(x[0])), files))
+        (os.path.join('share', 'snmpsim', *os.path.split(x[0])), files))
 
 if 'py2exe' in sys.argv:
 

--- a/snmpsim/confdir.py
+++ b/snmpsim/confdir.py
@@ -41,12 +41,14 @@ elif sys.platform == 'darwin':
 else:
     variation = [
         os.path.join(os.environ['HOME'], '.snmpsim', 'variation'),
+        os.path.join('/', 'usr', 'local', 'share', 'snmpsim', 'variation'),
         os.path.join(sys.prefix, 'snmpsim', 'variation'),
         os.path.join(sys.prefix, 'share', 'snmpsim', 'variation'),
         os.path.join(os.path.split(__file__)[0], 'variation')
     ]
     data = [
         os.path.join(os.environ['HOME'], '.snmpsim', 'data'),
+        os.path.join('/', 'usr', 'local', 'share', 'snmpsim', 'data'),
         os.path.join(sys.prefix, 'snmpsim', 'data'),
         os.path.join(sys.prefix, 'share', 'snmpsim', 'data'),
         os.path.join(os.path.split(__file__)[0], 'data')


### PR DESCRIPTION
Currently when try use variation modules, get this error:
```
ERROR data error at BlackPearl.snmprec controller for 1.3.6.1.4.1.3478.6.3.4.1.1.4: Variation module "numeric" referenced but not loaded
```
This fix path for variation and data dirs to share on unix oses:
old: `/usr/local/snmpsim/variation`,
new: `/usr/local/share/snmpsim/variation`
old: `/usr/local/snmpsim/data`,
new: `/usr/local/share/snmpsim/data`